### PR TITLE
pin jinja2 version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   publish:
@@ -21,6 +24,7 @@ jobs:
             done
       - run: mv README.md lunchtime* dist/.
       - uses: JamesIves/github-pages-deploy-action@v4.2.5
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         name: Deploy to gh-pages
         with:
           branch: gh-pages

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ click==8.0.3
 pytest==7.0.1
 ipytest==0.11.0
 pillow==9.0.1
+jinja2==3.0.3


### PR DESCRIPTION
- avoid nbconvert bug with more recent jinja2 versions
- also run nbconvert part of publish CI on PRs
- resolves #25
